### PR TITLE
Testing catchup jan17

### DIFF
--- a/src/_tests_/components/DeleteScript.spec.ts
+++ b/src/_tests_/components/DeleteScript.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it,vi,beforeEach} from 'vitest';
+import DeleteScript from '@/components/DeleteScript.vue';
+import { useScriptStore } from '@/stores/ScriptStore';
+import { createPinia,setActivePinia } from 'pinia';
+import { mount } from '@vue/test-utils';
+import {type AxiosResponse} from 'axios';
+import { useRouter } from 'vue-router';
+import scriptService from '@/services/scriptService';
+
+let wrapper;
+vi.mock('@/services/scriptService');
+
+describe('DeleteScript.vue', () => {
+    // Mock Vue Router
+ vi.mock('vue-router', async () => {
+    const actual = await vi.importActual('vue-router');
+    return {
+      ...actual,
+      useRouter: vi.fn().mockReturnValue({
+        push: vi.fn(),
+      }),
+    };
+  });
+
+    beforeEach(() => {
+     sessionStorage.clear();
+     setActivePinia(createPinia());
+    
+      });
+      const mockScripts = [
+        {
+          scriptId: 1,
+          name: 'Script One',
+          body: 'Testing One Script',
+        },
+        {
+          scriptId: 2,
+          name: 'Script Two',
+          body: 'Testing a Second Script',
+        },
+        {
+        scriptId: 3,
+        name: 'Script Three',
+        body: 'Testing a Third Script',
+          },
+      ]
+      
+      it('deletes script with correct ID from backend & ScriptStore on success', async () => {
+
+        //arrange
+        const scriptStore = useScriptStore()
+        scriptStore.setScripts(mockScripts);
+        scriptStore.setScript(mockScripts[1]);
+        wrapper = mount(DeleteScript)
+        const toggleButton = wrapper.find('#toggle-button');
+        
+
+        const mockScriptID = 2;
+       
+        const mockResponse: AxiosResponse<any, any> = {
+          status: 200, 
+          data:{}, 
+            statusText:'',
+        headers: {},
+        config: {} as any,}
+      
+        vi.mocked(scriptService.deleteScriptById).mockResolvedValue(mockResponse);
+        await toggleButton.trigger('click');
+        await wrapper.vm.$nextTick();
+        const yesButton = wrapper.find('#yes-button');
+        //act
+        await yesButton.trigger('click');
+
+        //assert
+        expect(scriptService.deleteScriptById).toHaveBeenCalledOnce();
+        expect(scriptService.deleteScriptById).toHaveBeenCalledWith(mockScriptID);
+        expect(scriptStore.scripts.length).toEqual(2);
+        expect(scriptStore.scripts[1].scriptId).toEqual(3);
+
+      })
+    });

--- a/src/_tests_/components/UpdateScript.spec.ts
+++ b/src/_tests_/components/UpdateScript.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it,vi,beforeEach,afterEach } from 'vitest';
+import UpdateScript from '@/components/UpdateScript.vue';
+import ScriptConsole from '@/components/ScriptConsole.vue';
+import { useScriptStore } from '@/stores/ScriptStore';
+import { createPinia } from 'pinia';
+import { mount } from '@vue/test-utils';
+import {type AxiosResponse} from 'axios';
+import scriptService from '@/services/scriptService';
+
+let wrapper;
+vi.mock('@/services/scriptService');
+const props = {
+  name: 'Test Script',
+  body: "Hello world!",
+  modelValue: false
+ }
+
+describe('UpdateScript.vue', () => {
+
+ beforeEach(() => {
+  vi.resetAllMocks();
+   });
+   it('renders properly', () => {
+    const pinia = createPinia()
+   const store = useScriptStore(pinia)
+    wrapper = mount(UpdateScript);
+    expect(wrapper.findComponent(UpdateScript).exists()).toBe(true);
+  });
+})

--- a/src/_tests_/services/authService.spec.ts
+++ b/src/_tests_/services/authService.spec.ts
@@ -43,6 +43,30 @@ it('should handle errors when logging in a user', async () => {
  }
 });
 
+it('Register should register a new user', async () => {
+  const newUser = {username: 'newguy3', email: 'newguy3@gmail.com', password: 'newguy3'};
+  const response = {};
+  mockAxiosPost.mockResolvedValue(response);
+
+  const result = await authService.register(newUser);
+  expect(result).toBe(response);
+  expect(mockAxiosPost).toHaveBeenCalledWith('api/auth/register', newUser);
+});
+
+it('Register should handle errors when failing to register', async () => {
+  const newUser = {};
+  const error = new Error('Network Error');
+  mockAxiosPost.mockRejectedValue(error);
+
+  try {
+    await authService.register(newUser);
+  } catch (e) {
+    expect(e).toBe(error);
+    expect(mockAxiosPost).toHaveBeenCalledWith('api/auth/register', newUser);
+  }
+});
+
 afterEach(() => {
  mockAxiosPost.mockReset();
-}); });
+}); 
+});

--- a/src/_tests_/stores/AuthStore.spec.ts
+++ b/src/_tests_/stores/AuthStore.spec.ts
@@ -1,5 +1,4 @@
 import {it,expect,describe,beforeEach,afterEach } from 'vitest'
-
 import { createPinia, setActivePinia } from 'pinia';
 import { useAuthStore } from '@/stores/AuthStore';
 import axios from 'axios';
@@ -13,18 +12,8 @@ describe('AuthStore', () => {
   authStore = useAuthStore();
  });
 
- it('should initialize the store with token and user from local storage', async () => {
-  // Arrange
-//   localStorage.setItem('token', 'testToken');
-//   localStorage.setItem('user', JSON.stringify({ name: 'test_user' }));
 
-  // Act
-  // Assert
-//   expect(authStore.token).toBe('testToken');
-//   expect(authStore.user).toEqual({ name: 'test_user' });
- });
-
- it('should set the auth token and update local storage and axios headers', () => {
+ it('should set the auth token and update local storage and axios headers during setAuthToken', () => {
   // Act
   authStore.setAuthToken('newToken');
 
@@ -32,6 +21,17 @@ describe('AuthStore', () => {
   expect(authStore.token).toBe('newToken');
   expect(localStorage.getItem('token')).toBe('newToken');
   expect(axios.defaults.headers.common['Authorization']).toBe(`Bearer newToken`);
+ });
+
+ it('should empty local storage and axios headers during logout()', () => {
+  //Arrange
+  authStore.setAuthToken('newToken');
+  //act
+  authStore.logout();
+  // Assert
+  expect(authStore.token).toBe('');
+  expect(localStorage.getItem('token')).toBeNull();
+  expect(axios.defaults.headers.common['Authorization']).toBeUndefined;
  });
 
  afterEach(() => {

--- a/src/_tests_/stores/ScriptStore.spec.ts
+++ b/src/_tests_/stores/ScriptStore.spec.ts
@@ -1,43 +1,69 @@
-import { test,describe,beforeEach} from 'vitest'
+import { test,describe,beforeEach,vi} from 'vitest'
 import { useScriptStore } from '../../stores/ScriptStore'
 import { createPinia, setActivePinia } from 'pinia';
+import { afterEach } from 'node:test';
 
 describe('ScriptStore', () => {
     beforeEach(() => {
       setActivePinia(createPinia());
     });
+    afterEach(()=>{
+      sessionStorage.clear();
+    })
+    
+    const mockScripts = [
+      {
+        scriptId: 1,
+        name: 'Script One',
+        body: 'Testing One Script',
+      },
+      {
+        scriptId: 2,
+        name: 'Script Two',
+        body: 'Testing a Second Script',
+      },
+    ]
 
-
-
-test('should set all scripts', ({ expect }) => {
+test('setScripts should set all scripts', ({ expect }) => {
  const store = useScriptStore()
- const newScripts = [
-   {
-     scriptId: 3,
-     name: 'Script Three',
-     body: 'Testing a Third Script',
-   },
-   {
-     scriptId: 4,
-     name: 'Script Four',
-     body: 'Testing a Fourth Script',
-   },
- ]
-
- store.setScripts(newScripts);
-
- expect(store.scripts).toEqual(newScripts)
+ store.setScripts(mockScripts);
+ expect(store.scripts).toEqual(mockScripts)
 })
-test('should set a single script', ({ expect }) => {
+
+test('setScript should set a single script in store and sessionStorage', ({ expect }) => {
   const store = useScriptStore();
+  store.setScript(mockScripts[1]);
+
+  expect(store.script).toEqual(mockScripts[1]);
+  expect(sessionStorage.getItem('script')).toBe(JSON.stringify(mockScripts[1]))
+});
+
+test('addNewScript should add a new script to scripts', ({ expect }) => {
+  const store = useScriptStore()
+  store.setScripts(mockScripts);
+
   const newScript = {
-      scriptId: 5,
-      name: 'Script Five',
-      body: 'Testing a Fifth Script',
+    scriptId: 3, 
+    name: "New Script", 
+    body:"Testing a New Script"
   };
 
-  store.setScript(newScript);
-
-  expect(store.script).toEqual(newScript);
+  store.addNewScript(newScript);
+  expect(store.scripts.length).toEqual(3);
+  expect(store.scripts[2]).toEqual(newScript);
+  store.scripts.pop();
+  
 });
+
+test('deleteScript should return new array containing scripts without script with parameter ID', async ({ expect }) => {
+  const store = useScriptStore();
+
+  store.setScripts(mockScripts);
+
+  store.deleteScript(2);
+ 
+  expect(store.scripts.length).toEqual(1);
+  expect(store.scripts[0].scriptId).toEqual(1);
+});
+
 })

--- a/src/_tests_/views/RegisterView.spec.ts
+++ b/src/_tests_/views/RegisterView.spec.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { type AxiosResponse } from 'axios';
+import RegisterView from '@/views/RegisterView.vue';
+import authService from '@/services/authService';
+import { useRouter } from 'vue-router';
+
+let wrapper;
+vi.mock('@/services/authService');
+vi.mock('vue-router', async () => {
+    const actual = await vi.importActual('vue-router');
+    return {
+        ...actual,
+        useRouter: vi.fn().mockReturnValue({
+            push: vi.fn(),
+        }),
+    };
+});
+
+describe('RegisterView.vue', () => {
+    const pinia = createPinia();
+
+    beforeEach(() => {
+        setActivePinia(pinia);
+    });
+
+    it('User is able to register successfully and is pushed to login screen', async () => {
+        wrapper = mount(RegisterView, {
+            global: { plugins: [pinia] },
+        });
+
+        const mockNewUser = {username: 'newguy', email:'newguy@gmail.com', password: 'newguy1'};
+
+        const mockResponse: AxiosResponse<any, any> = {
+            data: {email:'newguy@gmail.com', id: 2, username: 'newguy'},
+            status: 201,
+            statusText: "",
+            headers: {},
+            config: {} as any,
+        };
+
+        vi.mocked(authService.register).mockResolvedValue(mockResponse);
+
+        const usernameInput = wrapper.find('input[type="text"]');
+        const emailInput = wrapper.find('input[type="email"]');
+        const passwordInput = wrapper.find('#password');
+        const passwordConfirmInput = wrapper.find('#passwordDuplicate');
+        await usernameInput.setValue('newguy');
+        await emailInput.setValue('newguy@gmail.com');
+        await passwordInput.setValue('newguy1');
+        await passwordConfirmInput.setValue('newguy1');
+
+        const registerButton = wrapper.find('button');
+        const spy = vi.spyOn(registerButton, 'trigger');
+        await registerButton.trigger('submit.prevent');
+
+        expect(authService.register).toHaveBeenCalledWith(mockNewUser);
+        expect(spy).toHaveBeenCalledOnce;
+        expect(useRouter().push).toHaveBeenCalledWith('/login');
+    })
+
+    it('Displays an error message if passwords do not match', async () => {
+        wrapper = mount(RegisterView, {
+            global: { plugins: [pinia] },
+        });
+
+        const mockNewUser = {username: 'newguy2', email:'newguy@gmail2.com', password: 'newguy2'};
+    
+        const usernameInput = wrapper.find('input[type="text"]');
+        const emailInput = wrapper.find('input[type="email"]');
+        const passwordInput = wrapper.find('#password');
+        const passwordConfirmInput = wrapper.find('#passwordDuplicate');
+        await usernameInput.setValue('newguy2');
+        await emailInput.setValue('newguy2@gmail.com');
+        await passwordInput.setValue('newguy2');
+        await passwordConfirmInput.setValue('newguy1');
+
+        const registerButton = wrapper.find('button');
+        const spy = vi.spyOn(registerButton, 'trigger');
+        await registerButton.trigger('submit.prevent');
+
+        expect(spy).toHaveBeenCalledOnce();
+        const errorMessage = wrapper.find('span')
+        expect(errorMessage.text()).toEqual('Passwords must be matching')
+    })
+
+    
+})

--- a/src/components/DeleteScript.vue
+++ b/src/components/DeleteScript.vue
@@ -1,8 +1,8 @@
 <template>
-  <button @click="toggleDelete">Delete Script</button>
+  <button id="toggle-button" @click="toggleDelete">Delete Script</button>
   <div v-if="showDelete">
     <h1>Are you sure you want to delete this script</h1>
-    <button @click="handleDelete">Yes</button>
+    <button id="yes-button" @click="handleDelete">Yes</button>
     <button @click="cancelDelete">No</button>
   </div>
 </template>

--- a/src/stores/ScriptStore.ts
+++ b/src/stores/ScriptStore.ts
@@ -28,10 +28,15 @@ export const useScriptStore = defineStore("script", {
     async addNewScript(script: Object){
       this.scripts.push(script);
     },
-    async deleteScript(id: number){
-      return this.scripts.filter((script: Object) => {
-        return (script as { scriptId: number; }).scriptId !== id;
-      });
+    deleteScript(id: number){
+
+      for(let i = 0; i<this.scripts.length;i++){
+        if (this.scripts[i].scriptId === id){
+          this.scripts.splice(i,1);
+          return this.scripts;
+        } 
+      }
+      return this.scripts;
      }
      
   },


### PR DESCRIPTION
Added tests to all front end files that require testing, except for DeleteScript.vue (to be done tomorrow). Note-> NewScript & UpdateScript tests do not currently test saving function because having trouble with mocking inputs from a child component/2-way binding v-model of another component. Finally refactored deleteScript() action in ScriptStore to splice script with targeted id, instead of return a filter.