### PR TITLE
Player script selector 872

### DIFF
--- a/src/components/PlayerScriptSelector.vue
+++ b/src/components/PlayerScriptSelector.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="player-script-container">
+    <div v-for="player in players" :key="player.name">
+      <label>{{ player.name }}</label>
+      <select v-model="player.selection">
+        <option disabled value="">Select a script</option>
+        <option v-for="script in scripts" :key="script.scriptId">
+          {{ script.name }}
+        </option>
+      </select>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useScriptStore } from '@/stores/ScriptStore';
+
+const scriptStore = useScriptStore();
+
+const players = ref([
+  { name: 'player 1', selection: '' },
+  { name: 'player 2', selection: '' },
+  { name: 'player 3', selection: '' },
+  { name: 'player 4', selection: '' },
+]);
+
+const scripts = computed(() => {
+  return scriptStore.scripts;
+});
+onMounted(async () => {
+  scriptStore.init();
+});
+</script>
+
+<style scoped>
+.player-script-container {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  padding: 20px;
+}
+</style>

--- a/src/components/PlayerScriptSelector.vue
+++ b/src/components/PlayerScriptSelector.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="player-script-container">
-    <div v-for="player in players" :key="player.name">
+    <div id="selector" v-for="player in players" :key="player.name">
       <label>{{ player.name }}</label>
       <select v-model="player.selection">
         <option disabled value="">Select a script</option>
@@ -15,17 +15,28 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
 import { useScriptStore } from '@/stores/ScriptStore';
+import { useAuthStore } from '@/stores/AuthStore';
 
 const scriptStore = useScriptStore();
+const userStore = useAuthStore();
 
 const players = ref([
-  { name: 'player 1', selection: '' },
-  { name: 'player 2', selection: '' },
-  { name: 'player 3', selection: '' },
-  { name: 'player 4', selection: '' },
+  { name: 'Player', selection: '' },
+  { name: 'Enemy 1', selection: '' },
+  { name: 'Enemy 2', selection: '' },
+  { name: 'Enemy 3', selection: '' },
 ]);
 
 const scripts = computed(() => {
+  //If/else & hardcoded array only for testing while we do not have a 'guest account' set up in backend.
+  if (userStore.token === '') {
+    return [
+      { scriptId: 1, name: 'Cool Script', body: 'XYZ' },
+      { scriptId: 2, name: 'Lame Script', body: 'ABC' },
+      { scriptId: 3, name: 'Silly Script', body: 'DEF' },
+      { scriptId: 4, name: 'Cheese Script', body: 'JKI' },
+    ];
+  }
   return scriptStore.scripts;
 });
 onMounted(async () => {
@@ -37,7 +48,15 @@ onMounted(async () => {
 .player-script-container {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
-  padding: 20px;
+  gap: 0.8em;
+  padding: 1rem;
+}
+#selector {
+  display: flex;
+  flex-direction: column;
+}
+
+select {
+  padding: 5%;
 }
 </style>

--- a/src/stores/AuthStore.ts
+++ b/src/stores/AuthStore.ts
@@ -26,7 +26,7 @@ export const useAuthStore = defineStore("auth", {
 
 		logout() {
 			localStorage.removeItem('token');
-			
+						
 			this.token = '';
 			
 		

--- a/src/views/LobbyView.vue
+++ b/src/views/LobbyView.vue
@@ -4,7 +4,7 @@
 
     <MapCarousel @fetchMapIndex="fetchMapIndex" />
 
-    <div style="border: 1px black solid">DROP DOWN MENUS</div>
+    <PlayerScriptSelector />
 
     <div class="button-section">
       <button @click="$router.push('/scripts')" style="background-color: green">
@@ -18,6 +18,7 @@
 
 <script setup lang="ts">
 import MapCarousel from '@/components/MapCarousel.vue';
+import PlayerScriptSelector from '@/components/PlayerScriptSelector.vue';
 import { ref } from 'vue';
 
 const currentMapIndex = ref(0);

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -40,7 +40,7 @@ const login = () => {
         console.log(`Username: ${user.username}, Password: ${user.password}`);
         console.log(response);
         authStore.setAuthToken(response.data.token);
-        router.push('/scripts');
+        router.push('/lobby');
       }
     })
     .catch((e) => {
@@ -59,9 +59,9 @@ const login = () => {
 <style scoped>
 .login-page {
   display: grid;
-  grid-template-areas: 
-  "login-form" 
-  "register-link";
+  grid-template-areas:
+    'login-form'
+    'register-link';
   justify-content: center;
   margin: auto;
   width: 100%;
@@ -69,7 +69,7 @@ const login = () => {
 }
 
 .login-form {
-  grid-area: "login-form";
+  grid-area: 'login-form';
   display: inline-grid;
   padding-top: 5px;
 }
@@ -95,8 +95,7 @@ button {
 }
 
 .register-link {
-  grid-area: "register-link";
+  grid-area: 'register-link';
   font-size: 15px;
 }
-
 </style>


### PR DESCRIPTION
Created PlayerScriptSelector visible in LobbyView. No test file needed. Currently, non-logged in guests use the script list hardcoded in the component. Logged-in Users use their scripts pulled from the backend.

To test front-to-back functionality, I wrote the following scripts into the bottom of my resources/data.sql file. I recommend doing the same if you have not:

--Scripts
INSERT INTO scripts (name,body,date_created,date_updated,owner_id)
VALUES
('Script 1','START','2024-01-01','2024-01-03',(SELECT id FROM users WHERE username = 'test_user'));
INSERT INTO scripts (name,body,date_created,date_updated,owner_id)
VALUES
('Script 2','ATTACK','2024-01-04','2024-01-04',(SELECT id FROM users WHERE username = 'test_user'));
INSERT INTO scripts (name,body,date_created,date_updated,owner_id)
VALUES
('Script 3','EAT','2024-01-06','2024-01-10',(SELECT id FROM users WHERE username = 'test_user'));
INSERT INTO scripts (name,body,date_created,date_updated,owner_id)
VALUES
('Script 4','LEFT RIGHT','2024-01-09','2024-01-09',(SELECT id FROM users WHERE username = 'test_user'));
INSERT INTO scripts (name,body,date_created,date_updated,owner_id)
VALUES
('Script 5','FINISH','2024-01-09','2024-01-09',(SELECT id FROM users WHERE username = 'test_user'));

Also, Edited login() on LoginView to push user to Lobby, removed auth requirement from /scripts on router/index.ts so guests can see scripts without logging in. Checked something in AuthStore but didn't re-delete the correct amount of empty lines somewhere, so it may say I change it.

